### PR TITLE
Fix string read

### DIFF
--- a/aston/tracefile/agilent_uv.py
+++ b/aston/tracefile/agilent_uv.py
@@ -9,7 +9,18 @@ from aston.tracefile import TraceFile
 
 
 def string_read(f):
-    return f.read(struct.unpack('>B', f.read(1))[0]).decode('ascii').strip()
+    """modified string read method which works with our UV files"""
+    # todo figure out why there is a null character between every value
+    #   - check if this is true across all cases
+    #   - if so, does this affect the interpretation of intensity values
+    # it's not pretty, but it works
+    read_len = struct.unpack(  # determine length to read
+        '>B', f.read(1)
+    )[0]
+    out = f.read(  # read values, decode, and strip
+        2 * read_len - 1
+    ).decode('ascii').strip()
+    return out.replace('\x00', '')
 
 
 class AgilentMWD(TraceFile):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-# import matplotlib
 import os
 
 from aston import __version__
@@ -39,7 +38,7 @@ options = {
     # 'data_files': matplotlib.get_py2exe_datafiles(),
     'package_data': {'aston': []},
     'include_package_data': True,
-    'install_requires': ['numpy==1.16.4', 'scipy>=1.2.0'],
+    'install_requires': ['numpy>=1.16.4', 'scipy>=1.2.0'],
     'extras_require': {
         'plot': ['matplotlib', 'jupyter'],
     }


### PR DESCRIPTION
When attempting to use Aston for reading some Agilent .D files I discovered that the `string_read` function was only returning ~half of the target value (e.g. returning `mA` instead of `mAU` for the units of DAD intensity). Presumably this is related to the utf-16 encoding of the files. Additionally, the returned value had null characters included. I had a go at adjusting the function so that the correct value was returned (reading the correct value and removing the `\x00` characters). Perhaps this was not quite the right way to do it but we have been using this branch for some time now and everything appears to work with the classes we use (primarily `aston.tracefile.agilent_uv.AgilentCSDAD2`). 


Additionally I modified the `numpy` requirement in `setup.py` as we need a newer version than the hard-coded `1.16.4`. Everything appears to function with the newer version of `numpy`. 

I ran your test suite and most tests ran without error. Only `test_peak_finding.py` returned errors, although it should be noted that the same errors appear in the `master` branch. 
