### PR TITLE
Remove prints

### DIFF
--- a/aston/__init__.py
+++ b/aston/__init__.py
@@ -2,4 +2,4 @@
 Aston
 """
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/aston/tracefile/agilent_ms.py
+++ b/aston/tracefile/agilent_ms.py
@@ -158,9 +158,9 @@ class AgilentMS(TraceFile):
 
             # TODO: use numpy.fromfile?
             nions = np.fromfile(f, dtype='>H', count=npts * 2)[0::2]
-            if scn < 2:
-                print(npts)
-                print(nions)
+            # if scn < 2:
+            #     print(npts)
+            #     print(nions)
             # nions = struct.unpack('>' + npts * 'HH', f.read(npts * 4))[0::2]
             ions.update(nions)
             f.seek(npos)

--- a/aston/tracefile/agilent_uv.py
+++ b/aston/tracefile/agilent_uv.py
@@ -429,7 +429,7 @@ class AgilentCSDAD2(TraceFile):
             # for idx in np.hstack([oob_idxs, data.shape[0]]):
             #     ndata[i, pidx:idx] = np.cumsum(data[pidx:idx])
             #     pidx = idx
-
+        f.close()
         return Chromatogram(ndata / 2000., times / 60000., wvs, yunits=yunits)
 
     @property


### PR DESCRIPTION
Fixed a couple of annoying but non-critical bugs. 
- the open file in `AgilentCSDAD2` is now closed after data processing is complete 
- the print statements from the `AgilentMS.old_data` property have been commented out. In PyCharm when debugging, properties are frequently updated for namespace inspection and this resulted in a _lot_ of prints to console 
- incremented version to 0.7.1 to indicate changes on pypi