### PR TITLE
leverage wavlength index list rather than indexing for every intensity

### DIFF
--- a/aston/__init__.py
+++ b/aston/__init__.py
@@ -2,4 +2,4 @@
 Aston
 """
 
-__version__ = '0.7.1'
+__version__ = '0.7.2'


### PR DESCRIPTION
We've been needing to do some batch processing and some users have been complaining that the conversion is too slow. I did some profiling and found that the wavelength indexing was by far the slowest step. I created a wavelength index list based on the ordering in the `wvs` list and reference those indicies when setting data in the array. 

At least in the files that I have, the wavelength list does not appear to change order, so this should be a safe change. Have you encountered any situations where this order changes? If not, it might be possible to apply this change across the package. 